### PR TITLE
filter for JIT Optimizing programs ONLY

### DIFF
--- a/Sources/Fuzzilli/Configuration.swift
+++ b/Sources/Fuzzilli/Configuration.swift
@@ -73,6 +73,11 @@ public struct Configuration {
     // differential fuzzers can inspect (via mutating the JS program to print defined variables).
     public let forDifferentialFuzzing: Bool
 
+    // If true, only programs that trigger JIT compilation will be kept in the corpus.
+    // This is useful for targeting JIT-specific bugs. When enabled, programs that don't
+    // set any TurboFan optimization bits will be discarded immediately during evaluation.
+    public let targetJitOnly: Bool
+
     // The subdirectory in {config.storagePath} at which all programs are stored which could not
     // be imported due to disabled wasm capabilities in the fuzzer.
     public static let excludedWasmDirectory = "excluded_wasm_programs"
@@ -91,7 +96,8 @@ public struct Configuration {
                 tag: String? = nil,
                 isWasmEnabled: Bool = false,
                 storagePath: String? = nil,
-                forDifferentialFuzzing: Bool = false) {
+                forDifferentialFuzzing: Bool = false,
+                targetJitOnly: Bool = true) {
         self.arguments = arguments
         self.timeout = timeout
         self.logLevel = logLevel
@@ -106,6 +112,7 @@ public struct Configuration {
         self.isWasmEnabled = isWasmEnabled
         self.storagePath = storagePath
         self.forDifferentialFuzzing = forDifferentialFuzzing
+        self.targetJitOnly = targetJitOnly
     }
 }
 

--- a/Sources/Fuzzilli/Evaluation/ProgramCoverageEvaluator.swift
+++ b/Sources/Fuzzilli/Evaluation/ProgramCoverageEvaluator.swift
@@ -190,6 +190,13 @@ public class ProgramCoverageEvaluator: ComponentBase, ProgramEvaluator {
         let hasOptimizationDelta = optimizationDelta == 1
         let hasNewEdges = newEdgeSet.count > 0
 
+        if fuzzer.config.targetJitOnly {
+            // Optionally filter out programs that didn't trigger JIT compilation
+            if libcoverage.isOpted(&context) == 0 {
+                return nil
+            }
+        }
+
         if result == 1 || hasOptimizationDelta || hasFeedbackDelta {
             return hasNewEdges
                 ? CovEdgeSet(edges: newEdgeSet.edge_indices,

--- a/Sources/FuzzilliCli/main.swift
+++ b/Sources/FuzzilliCli/main.swift
@@ -101,6 +101,8 @@ Options:
                                    This can for example be used to remember the target revision that is being fuzzed.
     --wasm                       : Enable Wasm CodeGenerators (see WasmCodeGenerators.swift).
     --forDifferentialFuzzing     : Enable additional features for better support of external differential fuzzing.
+    --targetJitOnly              : Only keep programs that trigger JIT compilation in the corpus. This is enabled by default.
+                                   Use --no-targetJitOnly to disable and keep all programs regardless of JIT status.
     --postgres-url=url           : PostgreSQL connection string for PostgreSQL corpus (e.g., postgresql://user:pass@host:port/db).
     --validate-before-cache      : Enable program validation before caching in PostgreSQL corpus (default: true).
     --execution-history-size=n   : Number of recent executions to keep in memory for PostgreSQL corpus (default: 10).
@@ -162,6 +164,7 @@ let additionalArguments = args["--additionalArguments"] ?? ""
 let tag = args["--tag"]
 let enableWasm = args.has("--wasm")
 let forDifferentialFuzzing = args.has("--forDifferentialFuzzing")
+let targetJitOnly = !args.has("--no-targetJitOnly")  // Default is true (enabled), unless --no-targetJitOnly is specified
 let postgresUrl = args["--postgres-url"] ?? ProcessInfo.processInfo.environment["POSTGRES_URL"]
 let postgresLogging = args.has("--postgres-logging")
 
@@ -628,7 +631,9 @@ let mainConfig = Configuration(arguments: CommandLine.arguments,
                                staticCorpus: staticCorpus,
                                tag: tag,
                                isWasmEnabled: enableWasm,
-                               storagePath: storagePath)
+                               storagePath: storagePath,
+                               forDifferentialFuzzing: forDifferentialFuzzing,
+                               targetJitOnly: targetJitOnly)
 
 let fuzzer = makeFuzzer(with: mainConfig)
 
@@ -767,7 +772,9 @@ let workerConfig = Configuration(arguments: CommandLine.arguments,
                                  staticCorpus: staticCorpus,
                                  tag: tag,
                                  isWasmEnabled: enableWasm,
-                                 storagePath: storagePath)
+                                 storagePath: storagePath,
+                                 forDifferentialFuzzing: forDifferentialFuzzing,
+                                 targetJitOnly: targetJitOnly)
 
 for _ in 1..<numJobs {
     let worker = makeFuzzer(with: workerConfig)

--- a/Sources/libcoverage/coverage.c
+++ b/Sources/libcoverage/coverage.c
@@ -361,6 +361,10 @@ void clear_feedback_nexus(struct cov_context* context) {
     }
 }   
 
+int isOpted(struct cov_context* context) {
+    return context->turbofan_optimization_bits_current != 0;
+}
+
 int cov_evaluate_optimization_bits(struct cov_context* context) {
     if (!context->shmem) return 0;
     uint8_t delta = 0;

--- a/Sources/libcoverage/include/libcoverage.h
+++ b/Sources/libcoverage/include/libcoverage.h
@@ -161,6 +161,7 @@ void clear_feedback_nexus(struct cov_context* context);
 
 
 // Turbofan and Maglev optimization bits functions
+int isOpted(struct cov_context* context);
 int cov_evaluate_optimization_bits(struct cov_context* context);
 void cov_update_optimization_bits(struct cov_context* context);
 void clear_optimization_bits(struct cov_context* context);


### PR DESCRIPTION
Added a flag to trim (not include) programs that fail to JIT. This is useful for targetting JIT bugs because it reduces corpus that never JITs. This flag is set to true by default. Has been tested to confirm correctness.